### PR TITLE
update standards calendar of events for remaining 2019 and known 2020

### DIFF
--- a/standards-calendar.md
+++ b/standards-calendar.md
@@ -1,0 +1,36 @@
+# 2019 Calendar of Standards Meetings
+
+This list is not exhaustive - it reflects meetings we may or may not be interested in sending an OpenJS Foundation representative to on our behalf.
+
+## 2019
+
+| Date     | Event | Location | SDO | 
+|----------|-------|----------|-----|
+| 06.18-19 | TC53 In-person Meeting | Bay Area, CA | Ecma |
+| 06.26-27 | Ecma International General Assembly Meeting | Geneva | Ecma |
+| 07.23-25 | TC39 Plenary Meeting | Redmond | Ecma |
+| 09.16-20 | TPAC 2019 | Japan | W3C |
+| 09.18    | TC53 Meeting | Teleconference | Ecma | 
+| 10.01-03 | TC39 Plenary Meeting | NYC | Ecma |
+| 10.29-30 | TC53 Plenary Meeting | Boston | Ecma |
+| 11.20    | TC53 Meeting | Teleconference | Ecma |
+| 12.03-05 | TC39 Plenary Meeting | Bay Area, CA | Ecma |
+| 12.10-11 | Ecma International General Assembly Meeting | Tokyo | Ecma |
+| 12.11    | TC53 Plenary Meeting | Tokyo | Ecma |
+
+## 2020
+
+| Date     | Event | Location | SDO | 
+|----------|-------|----------|-----|
+| 02.04-06 | TC39 Plenary Meeting | University of Honolulu / JSConfHI | Ecma |
+| 03.31-04.02 | TC39 Plenary Meeting | Cupertino, CA | Ecma |
+| 05.17-19 | AC 2020 | Seoul | W3C |
+| 06.02-04 | TC39 Plenary Meeting | Chicago | Ecma |
+| 06.17-18 | Ecma International General Assembly Meeting | Geneva | Ecma |
+| 07.21-23 | TC39 Plenary Meeting | Seattle | Ecma |
+| 09.22-24 | TC39 Plenary Meeting | Tokyo | Ecma |
+| 10.26-30 | TPAC 2020 | Vancouver | W3C |
+| 11.17-19 | TC39 Plenary Meeting | TBD | Ecma |
+| 12.09-10 | Ecma International General Assembly Meeting | TBD North America | Ecma |
+
+*To-do - add W3C working group meetings and workshops. See https://www.w3.org/participate/eventscal.html for all W3C events.*

--- a/standards-calendar.md
+++ b/standards-calendar.md
@@ -22,12 +22,15 @@ This list is not exhaustive - it reflects meetings we may or may not be interest
 
 | Date     | Event | Location | SDO | 
 |----------|-------|----------|-----|
+| 01.22-24 | CSS WG F2F | Igalia @ A Coruña | W3C |
 | 02.04-06 | TC39 Plenary Meeting | University of Honolulu / JSConfHI | Ecma |
 | 03.31-04.02 | TC39 Plenary Meeting | Cupertino, CA | Ecma |
+| 04.27-29 | CSS WG F2F | Apple @ Cork, Ireland | W3C |
 | 05.17-19 | AC 2020 | Seoul | W3C |
 | 06.02-04 | TC39 Plenary Meeting | Chicago | Ecma |
 | 06.17-18 | Ecma International General Assembly Meeting | Geneva | Ecma |
 | 07.21-23 | TC39 Plenary Meeting | Seattle | Ecma |
+| 07.27-31 | CSS WG F2F | Google @ Waterloo, ON or New York, NY | W3C |
 | 09.22-24 | TC39 Plenary Meeting | Tokyo | Ecma |
 | 10.26-30 | TPAC 2020 | Vancouver | W3C |
 | 11.17-19 | TC39 Plenary Meeting | TBD | Ecma |


### PR DESCRIPTION
This addresses #17 
Includes known events for TC39, TC53, and org-wide W3C.
Will need to be updated to add additional W3C working groups, workshops, or other standards orgs.