### PR TITLE
Disambiguate "meeting"

### DIFF
--- a/proposals/stage0/REQUIREMENTS/README.md
+++ b/proposals/stage0/REQUIREMENTS/README.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-This document is an outline the requirements of the Standards' representative.
+This document outlines requirements for the Standards committee's representatives.
 
 ## Who would be responsible?
 
@@ -21,13 +21,14 @@ The needs of projects and ecosystem stakeholders being delegated via the represe
 
 The requirements for the elected representatives are as follows:
 
-* They should be a regular member at the OpenJS Foundation.
-* They should be available to travel for the meetings.
-* They should be ready to handle the conflicts of interest that might arise.
-* They should focus / address the concerns from the OpenJS Foundation and its projects' prespective.
-* They should be update the community about the meetings (either present/write)
-* They should be responsible for making sure the agenda is ready before the meeting.
+* They should be a regular member at the OpenJS Foundation standards committee meetings.
+* They should be available to travel to standards organizations' meetings.
+* For any meeting at which they represent the OpenJS Foundation:
+  * They should be ready to handle any conflicts of interest that might arise.
+  * They should be responsible for making sure the agenda is ready before the meeting.
+  * They should focus / address concerns from the OpenJS Foundation's and its projects' prespectives.
+  * They should update the community about the meetings (either present/write).
 
 Questions that are essential to address before moving to next stage:
-* Will the existing communities are okay with OpenJS foundation nominating a representative?
-* How to ensure that these representatives do not become a backdoor for the enterprises?
+* Will existing communities be okay with OpenJS foundation nominating a representative?
+* How to ensure that these representatives do not become a backdoor for enterprises?

--- a/proposals/stage0/REQUIREMENTS/README.md
+++ b/proposals/stage0/REQUIREMENTS/README.md
@@ -21,7 +21,7 @@ The needs of projects and ecosystem stakeholders being delegated via the represe
 
 The requirements for the elected representatives are as follows:
 
-* They should be a regular member at the OpenJS Foundation standards committee meetings.
+* They should be a regular attendee of OpenJS Foundation meetings.
 * They should be available to travel to standards organizations' meetings.
 * For any meeting at which they represent the OpenJS Foundation:
   * They should be ready to handle any conflicts of interest that might arise.

--- a/proposals/stage0/REQUIREMENTS/README.md
+++ b/proposals/stage0/REQUIREMENTS/README.md
@@ -21,7 +21,7 @@ The needs of projects and ecosystem stakeholders being delegated via the represe
 
 The requirements for the elected representatives are as follows:
 
-* They should be a regular attendee of OpenJS Foundation meetings.
+* They should be a member of the OpenJS Foundation.
 * They should be available to travel to standards organizations' meetings.
 * For any meeting at which they represent the OpenJS Foundation:
   * They should be ready to handle any conflicts of interest that might arise.
@@ -30,5 +30,5 @@ The requirements for the elected representatives are as follows:
   * They should update the community about the meetings (either present/write).
 
 Questions that are essential to address before moving to next stage:
-* Will existing communities be okay with OpenJS foundation nominating a representative?
+* Will existing communities be okay with the OpenJS foundation nominating a representative?
 * How to ensure that these representatives do not become a backdoor for enterprises?


### PR DESCRIPTION
IIUC, the term "meeting" is used in two senses:
* A meeting of the OpenJS Foundation standards committee
* A meeting of a standards body at which the representative is representing the OpenJS Foundation

This change attempts to make clear which one is meant in each line item but does not attempt to otherwise change duties.

I'm not sure if this is a good edit, but I thought I'd throw it out there for comment.