### PR TITLE
doc: update member list with ncu-team sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,20 @@ For historical documents about our standards work as the jQuery Foundation and J
 ## Team Members
 
 <!-- ncu-team-sync.team(openjs-foundation/standards) -->
-- [@MylesBorins](https://github.com/MylesBorins) Myles Borins
+
+- [@antsmartian](https://github.com/antsmartian) - antsmartian
+- [@christian-bromann](https://github.com/christian-bromann) - Christian Bromann
+- [@craftninja](https://github.com/craftninja) - Emily Platzer
+- [@eemeli](https://github.com/eemeli) - Eemeli Aro
+- [@Eomm](https://github.com/Eomm) - Manuel Spigolon
+- [@gibson042](https://github.com/gibson042) - Richard Gibson
+- [@joesepi](https://github.com/joesepi) - Joe Sepi
+- [@jorydotcom](https://github.com/jorydotcom) - Jory Burson
+- [@LaRuaNa](https://github.com/LaRuaNa) - Onur Laru
+- [@littledan](https://github.com/littledan) - Daniel Ehrenberg
+- [@ljharb](https://github.com/ljharb) - Jordan Harband
+- [@mikesamuel](https://github.com/mikesamuel) - Mike Samuel
+- [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
+- [@sendilkumarn](https://github.com/sendilkumarn) - Sendil Kumar N
+
 <!-- ncu-team-sync end -->


### PR DESCRIPTION
Update with command `ncu-team sync README.md`

There is already a `Standards` team in the `openjs-foundation` github
org.

I believe this is from a prior collab summit but not 100%. I've added
members who had opened a PR, and there are a handful of other folks in
this update that were already members. I think if we want to remove any
folks we should have that as a separate conversation

This is to serve as an alternative to #44, #45, #46, #47, #48

Closes: #41