### PR TITLE
governance: getting permission to attend meetings

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -59,7 +59,7 @@ at external organizations as a representative of the OpenJS Foundation.
 If a member would like to attend a meeting as a delegate of the OpenJS Foundation
 they should open an issue stating:
 
-* The standards meeting they wish to attend
+* The standards meeting or series of meetings they wish to attend
 * The OpenJS Foundations relationship to this standards organization
 * The date and location of the meeting
 * If they will be attending in person or remotely

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,6 +64,7 @@ they should open an issue stating:
 * The date and location of the meeting or meetings
 * If they will be attending in person or remotely
 * The estimated cost to the foundation of their participation
+* The scope of the work they plan to participate in
 
 This issue should be labelled with `standards-agenda` and will be approved in the
 next team meeting via the consensus seeking process.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -54,7 +54,7 @@ agenda item and sends it as a pull request after the meeting.
 
 ## Attending External Standards Meetings
 
-At various times members of this committee will attend Standards Meetings
+At various times members of the Standards team or foundation projects will attend Standards Meetings
 at external organizations as a representative of the OpenJS Foundation.
 If a member would like to attend a meeting as a delegate of the OpenJS Foundation
 they should open an issue stating:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -52,6 +52,22 @@ cannot veto or remove items.
 The moderator is responsible for summarizing the discussion of each
 agenda item and sends it as a pull request after the meeting.
 
+## Attending External Standards Meetings
+
+At various times members of this committee will attend Standards Meetings
+at external organizations as a representative of the OpenJS Foundation.
+If a member would like to attend a meeting as a delegate of the OpenJS Foundation
+they should open an issue stating:
+
+* The standards meeting they wish to attend
+* The OpenJS Foundations relationship to this standards organization
+* The date and location of the meeting
+* If they will be attending in person or remotely
+* The estimated cost of their particiaption
+
+This issue should be labelled with `standards-agenda` and will be approved in the
+next team meeting via the consensus seeking process.
+
 ## Consensus Seeking Process
 
 The Team follows a

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -63,7 +63,7 @@ they should open an issue stating:
 * The OpenJS Foundation's relationship to this standards organization
 * The date and location of the meeting or meetings
 * If they will be attending in person or remotely
-* The estimated cost of their particiaption
+* The estimated cost to the foundation of their participation
 
 This issue should be labelled with `standards-agenda` and will be approved in the
 next team meeting via the consensus seeking process.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -60,7 +60,7 @@ If a member would like to attend a meeting as a delegate of the OpenJS Foundatio
 they should open an issue stating:
 
 * The standards meeting or series of meetings they wish to attend
-* The OpenJS Foundations relationship to this standards organization
+* The OpenJS Foundation's relationship to this standards organization
 * The date and location of the meeting or meetings
 * If they will be attending in person or remotely
 * The estimated cost of their particiaption

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,7 +61,7 @@ they should open an issue stating:
 
 * The standards meeting or series of meetings they wish to attend
 * The OpenJS Foundations relationship to this standards organization
-* The date and location of the meeting
+* The date and location of the meeting or meetings
 * If they will be attending in person or remotely
 * The estimated cost of their particiaption
 


### PR DESCRIPTION
This is a basic policy for getting consensus around attending standards
meetings.

PTAL