### PR TITLE
doc: sort members list alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenJS Foundation Standards Working Group
 
-The purpose of this repository is to provide a central coordination and documentation point for project communities about foundation standards activities. 
+The purpose of this repository is to provide a central coordination and documentation point for project communities about foundation standards activities.
 
-Interested parties can also [join our #standards channel](https://communityinviter.com/apps/js-foundation/join-openjs-foundation-on-slack) on Slack. 
+Interested parties can also [join our #standards channel](https://communityinviter.com/apps/js-foundation/join-openjs-foundation-on-slack) on Slack.
 
 For historical documents about our standards work as the jQuery Foundation and JS Foundation, please see this [repository](https://github.com/JSFoundation/standards).
 
@@ -13,18 +13,18 @@ For historical documents about our standards work as the jQuery Foundation and J
 - [@antsmartian](https://github.com/antsmartian) - antsmartian
 - [@bkardell](https://github.com/bkardell) - Brian Kardell
 - [@christian-bromann](https://github.com/christian-bromann) - Christian Bromann
-- [@craftninja](https://github.com/craftninja) - Emily Platzer
+- [@littledan](https://github.com/littledan) - Daniel Ehrenberg
 - [@dtex](https://github.com/dtex) - Donovan Buck
 - [@eemeli](https://github.com/eemeli) - Eemeli Aro
-- [@Eomm](https://github.com/Eomm) - Manuel Spigolon
-- [@gibson042](https://github.com/gibson042) - Richard Gibson
+- [@craftninja](https://github.com/craftninja) - Emily Platzer
 - [@joesepi](https://github.com/joesepi) - Joe Sepi
-- [@jorydotcom](https://github.com/jorydotcom) - Jory Burson
-- [@LaRuaNa](https://github.com/LaRuaNa) - Onur Laru
-- [@littledan](https://github.com/littledan) - Daniel Ehrenberg
 - [@ljharb](https://github.com/ljharb) - Jordan Harband
+- [@jorydotcom](https://github.com/jorydotcom) - Jory Burson
+- [@Eomm](https://github.com/Eomm) - Manuel Spigolon
 - [@mikesamuel](https://github.com/mikesamuel) - Mike Samuel
 - [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
+- [@LaRuaNa](https://github.com/LaRuaNa) - Onur Laru
+- [@gibson042](https://github.com/gibson042) - Richard Gibson
 - [@sendilkumarn](https://github.com/sendilkumarn) - Sendil Kumar N
 
 <!-- ncu-team-sync end -->


### PR DESCRIPTION
Sorting out the members list alphabetically, like it's done in the CPC repo.