### PR TITLE
Add MEMBER_REPRESENTATION.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,8 +25,6 @@ The following groups automatically qualify for membership and can request to be 
 * OpenJS Foundation CPC Members
 * OpenJS Foundation Project Maintainers
 
-Every team member is asked to document one's involvement in any of the standards organizations that person is regularly involved with.
-
 ## Team Meetings
 
 The Team meets bi-weekly on Zoom.us. A designated moderator

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,7 +25,7 @@ The following groups automatically qualify for membership and can request to be 
 * OpenJS Foundation CPC Members
 * OpenJS Foundation Project Maintainers
 
-Every team member is asked to document ones involvement in any of the standards organizations that person is regularly involved with.
+Every team member is asked to document one's involvement in any of the standards organizations that person is regularly involved with.
 
 ## Team Meetings
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,6 +25,8 @@ The following groups automatically qualify for membership and can request to be 
 * OpenJS Foundation CPC Members
 * OpenJS Foundation Project Maintainers
 
+Every team member is asked to document ones involvement in any of the standards organisation that person is regularly involved with.
+
 ## Team Meetings
 
 The Team meets bi-weekly on Zoom.us. A designated moderator

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,7 +25,7 @@ The following groups automatically qualify for membership and can request to be 
 * OpenJS Foundation CPC Members
 * OpenJS Foundation Project Maintainers
 
-Every team member is asked to document ones involvement in any of the standards organisation that person is regularly involved with.
+Every team member is asked to document ones involvement in any of the standards organizations that person is regularly involved with.
 
 ## Team Meetings
 

--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -3,7 +3,7 @@
 The following document lists OpenJS Foundation members and their representation to any standards organizations:
 
 * [TC39]
-  * <firstname> <lastname> (#issue)
+  * <fullname> (#issue)
   * ...
 
 [TC39]: https://github.com/tc39

--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -1,6 +1,6 @@
 # Member Representation
 
-The following document lists OpenJS Foundation members and their representation to any standard organisations:
+The following document lists OpenJS Foundation members and their representation to any standards organizations:
 
 * <firstname> <lastname>
     * [TC39][1]

--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -6,4 +6,4 @@ The following document lists OpenJS Foundation members and their representation 
     * [TC39][1]
     * ...
 
-[1]: https://github.com/tc39
+[TC39]: https://github.com/tc39

--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -3,7 +3,7 @@
 The following document lists OpenJS Foundation members and their representation to any standards organizations:
 
 * <firstname> <lastname>
-    * [TC39][1]
+    * [TC39][]
     * ...
 
 [TC39]: https://github.com/tc39

--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -1,0 +1,9 @@
+# Member Representation
+
+The following document lists OpenJS Foundation members and their representation to any standard organisations:
+
+* <firstname> <lastname>
+    * [TC39][1]
+    * ...
+
+[1]: https://github.com/tc39

--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -2,8 +2,8 @@
 
 The following document lists OpenJS Foundation members and their representation to any standards organizations:
 
-* <firstname> <lastname>
-    * [TC39][]
-    * ...
+* [TC39]
+  * <firstname> <lastname> (#issue)
+  * ...
 
 [TC39]: https://github.com/tc39


### PR DESCRIPTION
As discussed in #67 this patch adds a markdown file to document team members involvement in standard organisations.