### PR TITLE
chore: rename master references to HEAD

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -31,4 +31,4 @@ For reporting issues in spaces managed by the OpenJS Foundation, for example, re
 The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `"coc-escalation@lists.openjsf.org`.
 
 For more information, refer to the full
-[Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+[Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/HEAD/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).

--- a/MEMBER_EXPECTATIONS.md
+++ b/MEMBER_EXPECTATIONS.md
@@ -1,6 +1,6 @@
 # Member Expectations
 
-All participants in the OpenJS Foundation projects and groups must follow the [Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md).
+All participants in the OpenJS Foundation projects and groups must follow the [Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CODE_OF_CONDUCT.md).
 There are further expectations for members who represent the Standards Working Group (hereafter called representatives).
 
 It is understood that representatives may form opinions based on the needs of their employers' or their personal projects. While representing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Standards Working Group actively monitors evolving standards to educate proj
 
 The purpose of this repository is to provide a central coordination and documentation point for project communities about foundation standards activities.
 
-The Standards Working Group's responsibilities, as ratified by the OpenJS Foundation's Cross Project Council, can be found in the [CPC's Working Groups Document](https://github.com/openjs-foundation/cross-project-council/blob/master/WORKING_GROUPS.md#standards)
+The Standards Working Group's responsibilities, as ratified by the OpenJS Foundation's Cross Project Council, can be found in the [CPC's Working Groups Document](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/WORKING_GROUPS.md#standards)
 
 Interested parties can also [join our #standards channel](https://communityinviter.com/apps/js-foundation/join-openjs-foundation-on-slack) on Slack.
 

--- a/meeting-notes/2019.07.02_meeting_notes.md
+++ b/meeting-notes/2019.07.02_meeting_notes.md
@@ -41,8 +41,7 @@ BK: Yes, this is a great example, +1 to that idea.
 Asking for feedback on specific proposals
 Outreach things that Dan et al are doing around TC39
 See stage-0 proposals
-https://github.com/openjs-foundation/cross-project-council/tree/master/proposals/stage-0/SHARED_INTERFACES 
-https://github.com/openjs-foundation/cross-project-council/tree/master/proposals/stage-0/STANDARDS_OUTREACH 
+https://github.com/openjs-foundation/cross-project-council/blob/HEAD/proposals/incubating/SHARED_INTERFACES/README.md
 Pre-meetings for TPAC, TC39 meetings
 BUDDY SYSTEM!
 Play a connector role around standards and working groups

--- a/meeting-notes/2019.07.02_meeting_notes.md
+++ b/meeting-notes/2019.07.02_meeting_notes.md
@@ -42,6 +42,7 @@ Asking for feedback on specific proposals
 Outreach things that Dan et al are doing around TC39
 See stage-0 proposals
 https://github.com/openjs-foundation/cross-project-council/blob/HEAD/proposals/incubating/SHARED_INTERFACES/README.md
+https://github.com/openjs-foundation/cross-project-council/blob/HEAD/proposals/incubating/STANDARDS_OUTREACH/README.md
 Pre-meetings for TPAC, TC39 meetings
 BUDDY SYSTEM!
 Play a connector role around standards and working groups

--- a/meeting-notes/2019.09.10_meeting_notes.md
+++ b/meeting-notes/2019.09.10_meeting_notes.md
@@ -30,7 +30,7 @@ Jordan Harband (@ljharb)
 
 * Document governance for the standards-wg [#19](https://github.com/openjs-foundation/standards/issues/19)
 
-We can use the [cpc governance doc](https://github.com/openjs-foundation/cross-project-council/blob/master/GOVERNANCE.md) to start as a starter. 
+We can use the [cpc governance doc](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/GOVERNANCE.md) to start as a starter. 
 Brian + Jory + TPAC group to workshop a draft next week to share with the group
 
 * Define and Document the on-boarding process for the Representative [#14](https://github.com/openjs-foundation/standards/issues/14)


### PR DESCRIPTION
Part of https://github.com/openjs-foundation/cross-project-council/issues/711

/master/HEAD/s