### PR TITLE
Chore: add notes files to minutes directory

### DIFF
--- a/meeting-notes/2021-08-10_meeting_notes.md
+++ b/meeting-notes/2021-08-10_meeting_notes.md
@@ -1,0 +1,63 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-08-10
+
+## Links
+
+* **Recording**: session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+* Robin Ginn (@rginn)
+* Richard Gibson (@gibson042) 
+* Hemanth HM (@hemanth) 
+* Jory Burson (@jorydotcom) 
+* Mike Samuel (@mikesamuel)
+
+## Agenda
+
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+SXSW Panel picker for south by - vote
+OpenJS World
+W3C AC Chat
+Book club
+
+### openjs-foundation/standards
+ Minutes
+
+* Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+
+Document broadly 
+Poke #standards channel peeps
+
+* Standards ed site
+https://github.com/openjs-foundation/standards-ed-site
+Unknotting
+Disentangling
+Acronyms
+wise information of standards and technology (WIST, WISTful)
+Wisteria - flowering (gardening)
+Wistopia 
+List of people who can mentor
+
+
+AOB
+OpenJS World - Austin, June 7-8 - reach out to Robin or Jory if you’re interested in convening a standards meeting there. We’ve already reached out to TC39 co-chairs.
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.08.24_meeting_notes.md
+++ b/meeting-notes/2021.08.24_meeting_notes.md
@@ -1,0 +1,46 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-08-24
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+Jordan Harband
+Sonal Bhoraniya
+Richard Gibson
+Hemanth HM
+Jory Burson
+Mike Samuel
+
+## Agenda
+
+### Announcements
+
+TC39 meeting next week!
+
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+
+
+https://docs.google.com/document/d/1vnYJFnVB3wHsIRWNiLnes48PgDgkuaxCqdlJFg-RdO4/edit
+
+TPAC - next time
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.09.07_meeting_notes.md
+++ b/meeting-notes/2021.09.07_meeting_notes.md
@@ -1,0 +1,52 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-09-07
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+* Jordan Harband
+* Michael Champion
+* Richard Gibson
+* Hemanth HM
+* Robin Ginn
+* Jory Burson
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+* TC39 - https://dev.to/hemanth/updates-from-the-85th-meeting-of-tc39-2kep
+* Book Club today @ 3 p.m. ET
+* Web Directions Conference happenings - PWA only conf happening
+* AC Office Hours
+* W3C TPAC - October
+
+### openjs-foundation/standards
+
+* Creative Services Brief: https://docs.google.com/document/d/1vnYJFnVB3wHsIRWNiLnes48PgDgkuaxCqdlJFg-RdO4/edit
+
+* https://documentation.divio.com/#about-the-system
+* https://docusaurus.io/
+
+
+*  Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.09.21_meeting_notes.md
+++ b/meeting-notes/2021.09.21_meeting_notes.md
@@ -1,0 +1,53 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-09-21
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+Robin
+Hemanth
+Eemeli
+Jordan
+Jory
+
+## Agenda
+
+### Announcements
+
+Marketing COmmittee Meeting today
+Speaking next week at OSSNA Seattle
+The Next Web Conf
+Patches
+Web Directions
+EasyCLA Working Session
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* W3C TAG Nominations to Open Soon [#157](https://github.com/openjs-foundation/standards/issues/157)
+
+* Support Liaison Travel for Unicode Conference [#156](https://github.com/openjs-foundation/standards/issues/156)
+  * No concerns - proceed
+  * Check in with Ben 
+  * Communicate Social / RE Eemeli Aro
+
+* Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.10.05_meeting_notes.md
+++ b/meeting-notes/2021.10.05_meeting_notes.md
@@ -1,0 +1,56 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-10-05
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+* Donovan Buck (@dtex) 
+* Jordan Harband (@ljharb)
+* Eemeli Aro (@eemeli) 
+* Richard Gibson (@gibson42)
+* Sonal Bhoraniya () 
+* Joe Sepi (@joesepi)
+* Robin Ginn (@rginn) 
+* Jory Burson (@jorydotcom) 
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+* Node LiFT Scholarship open through Oct. 15!
+* Programming Committee Meeting - Thursday!
+* OpenJS CPC 
+* SOS Announcements (https://sos.dev/)
+* OpenSSF Projects Looking to support JavaScript projects
+* TC39 Meeting Oct. 25-28
+* TC39 TPAC
+
+### openjs-foundation/standards
+
+* W3C TAG Nominations to Open Soon [#157](https://github.com/openjs-foundation/standards/issues/157)
+
+* Support Liaison Travel for Unicode Conference [#156](https://github.com/openjs-foundation/standards/issues/156)
+
+* 
+
+* Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.10.19_meeting_notes.md
+++ b/meeting-notes/2021.10.19_meeting_notes.md
@@ -1,0 +1,58 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-10-19
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+* Robin Ginn (@rginn) 
+* Eemeli Aro (@eemeliaro) 
+* Richard Gibson (@gibson42) 
+* Jory Burson (@jorydotcom)
+* Hemanth HM (@hemanthHM)  
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+* Eemeli - spoke at the unicode conf from messageformat WG - went well! Spoke along with co-presenters - talk was recorded but not sure when / how available. Also had a wg meeting there and was nice to meet everyone in person. Plan for series of design documents to address challenging spec issues. Ratified at monthly WG meeting yesterday, and hoping to see progress go further - spec in some number of months or low number of years. Eemeli to share more info on how messageformat would advance through unicode tech spec. Eemeli to work with 
+* Lots of shipping happening - Node 17; nvm - adds support for windows; 
+* Monday TC39 meeting - BST 
+* TPAC Developer days - this week
+* NearForm Node Conf
+* Programming Committee meeting this week (Thursday) 
+* Marketing Committee call later today - noon pacific
+
+### openjs-foundation/standards
+
+* W3C TAG Nominations to Open Soon [#157](https://github.com/openjs-foundation/standards/issues/157)
+Closed 
+
+* Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+Jory to do a PR for next Client
+
+* Spec Ed site
+Design resource may be needed to unblock
+Jory doesn’t think they have started
+
+* Exciting TC39 Agenda next week
+Extending Null
+Stage 4 proposals
+Temporal changes
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.11.02_meeting_notes.md
+++ b/meeting-notes/2021.11.02_meeting_notes.md
@@ -1,0 +1,51 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-11-02
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: https://github.com/openjs-foundation/standards/issues/162
+
+
+## Present
+
+* Joe Sepi (@joesepi)
+* Richard Gibson (@gibson42) 
+* Jonathan Lipps
+* Jory Burson (@jorydotcom) 
+* Eemeli Aro
+* Robin Ginn (@rginn) 
+* Brian Kardell
+* Mike Samuel
+* Christian Bromann
+
+## Agenda
+
+### Announcements
+* New Node.js Releases
+* Joe Speaking at JS Poland event on Open Governance / OpenJS
+* TPAC last week, recordings now available online
+* Brian spoke recently about has() which is now in CSS from jQuery 
+* Robin, Jordan, Todd at the Member Summit this week 
+
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Discussing a standard for cross-platform UI-based app automation [#161](https://github.com/openjs-foundation/standards/issues/161)
+
+* Jonathan shared a presentation on ideas for a standard, “universal” UI automation framework
+
+* Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.11.16_meeting_notes.md
+++ b/meeting-notes/2021.11.16_meeting_notes.md
@@ -1,0 +1,51 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-11-16
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+* Robin Ginn (@rginn) 
+* Eemeli Aro (@eemeli) 
+* Jordan Harband (@ljharb)
+* Joe Sepi (@joesepi)
+* Hemanth 
+* Mike Samuel
+
+
+
+
+## Agenda
+
+### Announcements
+
+* Marketing Committee Meeting - noon pacific
+* CPC Working Session - after this call
+* Programming Committee for event - Thursday!
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Discussing a standard for cross-platform UI-based app automation [#161](https://github.com/openjs-foundation/standards/issues/161)
+
+* Document Delegates & Delegate Approval Process [#142](https://github.com/openjs-foundation/standards/issues/142)
+
+* 
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2021.12.14_meeting_notes.md
+++ b/meeting-notes/2021.12.14_meeting_notes.md
@@ -1,0 +1,54 @@
+# OpenJS Foundation Standards Working Group Meeting 2021-12-14
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+
+* Robin Ginn (@rginn)    
+* Eemeli Aro (@eemeli)   
+* Jory Burson (@jorydotcom)  
+* Joe Sepi (@joesepi) 
+* Michael Champion 
+
+## Agenda
+
+W3C TAG Election
+Nominations to be recorded per slack discussion
+
+Creative Services Meeting / List Website
+Discussion about adding copyright guidance for OpenJS projects who are defining specifications outside an organization; e.g. how to interpret/use “Community Spec” license.
+CS wants to meet with us to review designs/requirements
+
+Meetings resuming in January
+Robin to run meetings in Jory’s absence
+Jory encourages group to take up the topic of coordination / feedback between projects, their efforts and the standards organizations
+
+
+
+### Announcements
+
+* OpenJS World Programming Committee Meeting - Thursday
+* Today is Jory’s last meeting until she returns from Maternity Leave
+* OpenJS public meetings canceled for remaining 2 weeks of 2021
+
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.01.25_meeting_notes.md
+++ b/meeting-notes/2022.01.25_meeting_notes.md
@@ -1,0 +1,47 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-01-25
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+Robin Ginn
+Michael Champion
+Eemeli Aro
+Mike Samuel
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+
+## Agenda
+
+Update on LIST website (Learning in Standards & Technology). Graphic designer needed to complete the work. Robin recommended and consensus reached that we start the site as a web page on openjsf.org.
+
+Standards WG at OpenJS World 2022: Standards WG at OpenJS World 2022 · Issue #168 · openjs-foundation/standards (github.com)
+Discussion followed by Michael Champion’s points in issue.
+Use foundation as voice of the user.
+Explore ways to create a forum for filling in the cracks and expanding the social network of those providing feedback to standards orgs.
+Robin and Mike Samuel identified potential spec editors to ask for support.
+Recruit and train new editors.
+Explore training or breakout session at OpenJS World or during this event’s Collab Summit.
+Recognition. Explore awards to be presented at OpenJS World (similar to CNCF “Chop and carry wood awards)
+
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.02.08_meeting_notes.md
+++ b/meeting-notes/2022.02.08_meeting_notes.md
@@ -1,0 +1,42 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-02-08
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* Robin Ginn
+* Donovan Buck
+* Jordan Harband
+* Michael Champion
+
+
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Standards WG at OpenJS World 2022 [#168](https://github.com/openjs-foundation/standards/issues/168)
+Discussion around two of the three summarized points from the last meeting:
+Explore ways to recruit and train new editors.
+Recruiting is best done through current contributors.
+Education effort recommended through breakout session at OpenJS World. Invite Hemanth HM to share his ReadSpecWith.us content in a one-hour training session, with Jordan on hand to support.
+Explore recognition and awards program (potential addition to CPC Community Fund thank you program in development)
+For standards heroes, leverage and amplify the awards already given by Ecma and other standards orgs.
+As projects to identify their unsung heroes and work through the CPC on awards program presented at OpenJS World.
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.02.22_meeting_notes.md
+++ b/meeting-notes/2022.02.22_meeting_notes.md
@@ -1,0 +1,77 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-02-22
+
+## Links
+
+* **Recording**: https://www.youtube.com/watch?v=cc6ifK0pNxw
+* **GitHub Issue**: https://github.com/openjs-foundation/standards/issues/171
+
+## Present
+
+*  Robin Ginn
+* Joe Sepi (@joesepi)
+* Jordan Harband
+* Michael Champion
+* Richard Gibson
+
+
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Standards WG at OpenJS World 2022 [#168](https://github.com/openjs-foundation/standards/issues/168)
+
+Recognition / Awards: 
+Reframe achievements. Measure impact. Demonstrate to employer and industry accomplishments. OpenJS marketing / OpenJS World recognition. <
+
+TC39: Readme, bugs, implementations (transpilers, polyfills, early browser movement), respectful pushback, adding tests, spec editors
+
+W3C: like above. + organizing user groups
+
+Working in Public: a book describes how maintainers are often not rewarded. 
+
+Blog posts, conference talks, writing/improving MDN articles, general “evangelism” things (+1)
+
+FOSS/node contributions? 
+Process: identify people comprised of many positive actions in addition to creating specific buckets.
+
+First time contributors’ awards? 
+Before feature: design phase
+Implementation phase
+After feature: evangelize, educate / onboard
+Organize
+
+Design, Build, Teach?
+
+Execution: crowdsource / ask champions for proposals. Look at commits in project repos.
+
+Branding brainstorm:
+No stone unturned.
+JavaScriptLandia + (play on words)
+Don’t imply that you have to “do something” like code to be rewarded.
+Like GitHub Star
+Hero but not glorified
+Connectors
+Fruit behind the leaf
+Caterpillar
+Weeders
+Cultivators
+Ants
+Fungus
+Caretaker
+Green or groundskeeper
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.04.05_meeting_notes.md
+++ b/meeting-notes/2022.04.05_meeting_notes.md
@@ -1,0 +1,39 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-04-05
+
+## Links
+
+* **Recording**: Session was not recorded
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Standards WG at OpenJS World 2022 [#168](https://github.com/openjs-foundation/standards/issues/168)
+
+Theater space?
+
+Awards nominations now open: https://forms.gle/Na5DH3DAyCKj41b66
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.07.12_meeting_notes.md
+++ b/meeting-notes/2022.07.12_meeting_notes.md
@@ -1,0 +1,64 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-07-12
+
+## Links
+
+* **Recording**:
+* **GitHub Issue**: https://github.com/openjs-foundation/standards/issues/183 
+
+## Present
+
+Robin Ginn
+Jordan Harband
+Christian Bromann
+Donovan Buck
+Richard 
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+
+
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Define terms for SME Participation [#173](https://github.com/openjs-foundation/standards/issues/173)
+
+Expectations for participation. 
+Participation in Standards WG: Prep before and debrief after. (Regular WG attendance is encouraged but not required)
+Person is already a credible/established participant in relevant standards. 
+
+Possible reasons for declining:
+Another more appropriate funding source has not been explored
+Reputational issues we do not want associated with the foundation
+The standards arena in question is not sufficiently relevant to OpenJS
+The requester is not already a credible/established participant in the relevant standards arena (eg, no past record of participation)
+
+Requesting funds does not imply that the requester is representing OpenJS, and as such, there are no inherent constraints applied to their participation solely based on usage of funds.
+
+Add expense limit guidelines (ie lowest travel costs).
+Consider and clarify why remote participation is not an option.
+It is strongly recommended that you submit your request far enough in advance to get approval before making relevant expenditures. Review of requests will take at least 72 hours and may take considerably longer. 
+
+Approvers: At least one approver from each: Standards WG and CPC.
+
+Terms: 
+
+* Standards WG at OpenJS World 2022 [#168](https://github.com/openjs-foundation/standards/issues/168)
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.11.01_meeting_notes.md
+++ b/meeting-notes/2022.11.01_meeting_notes.md
@@ -1,0 +1,85 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-11-01
+
+## Links
+
+* **Recording**: https://youtube.com/live/_qzWR5Wow4M?feature=share
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* Joe Sepi (@joesepi)
+* Robin Ginn
+* Lea Verou
+* Michael Champion
+* Luke Schantz
+*Jordan Harband
+
+
+## Agenda
+
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* 2022-2023 Public Calendar for web standards group meetings [#191](https://github.com/openjs-foundation/standards/issues/191)
+  * discussed briefly but no comments/concerns
+
+* Concise Guide to Participating in Web Standards Document WIP [#190](https://github.com/openjs-foundation/standards/issues/190)
+
+Michael Champion shared link to document - Concise Guide to Improving Web Standards
+https://docs.google.com/document/d/1yDxUCnvZC23HfZXOz7OAbyWHZqqqNXBZHk0y3GBeIds/edit#heading=h.pzjcr6mk132n
+Feedback and help on documents.  Wordsmithing and making things more concise.
+Robin: Set a goal to have something published? And weigh in before publishing?
+Lea: Do we just start editing? (google docs is good for initial editing IMO)
+Michael: Google docs has history or could move to github. Whatever works for you as long as it is in writing.
+ Robin: Deadline of 2 weeks …. 4 weeks. Lea: Conscious of thanksgiving timing.
+Lea: Not obvious to people which speck contains each feature.  Look up on MDN.  Seems to be the best source. Has a bookmark to take to spec.
+Jordan: Series of questions to help determine which spec to point to.
+Luke: In plant/biology identification there is the concept of “dichotomous key” for identification.
+Jordan: Reading the Spec - Hemanth HM, PayPal & Jordan Harband, Coinbase https://www.youtube.com/watch?v=uPFOdaGe9Zw
+
+
+
+
+* Submit Foundation Ballot for W3C Board Election [#189](https://github.com/openjs-foundation/standards/issues/189)
+
+	Issue closed.
+
+* Define terms for SME Participation [#173](https://github.com/openjs-foundation/standards/issues/173)
+
+Jordan: Consider the $ will change between request and approval times.  
+Lea: Range of prices.
+Robin: Linking standards and eligibility criteria. Active participation in the group etc.
+This was fleshed out but standards section is blank:
+https://github.com/openjs-foundation/community-fund/blob/main/programs/travel-fund.md
+Each group makes a decision on who they want to support.
+Robin: case by case basis. May need to be different criteria for some with yearly approval of x number of meetings.  Up to a certain point because we have a finite budget.
+Eligibility criteria and DEI scholarships. 
+Recommendation for eligibility
+Person be representative for XYZ meeting N number of meetings this year.
+Lea: look into how it is listed as an innovative and if it complicates work or student visa.
+If it shows up as income.
+Jordan: reimbursement is not income. Filing a report does not necessarily make it income. Important concern that should be independent of the platform we use.
+Robin: Work on language from a process perspective and make suggestions.
+
+
+## Q&A, Other
+
+Lea: Tag nominations end next week. Do I need to open an issue? Lea is up for reelection as her term is ending. It is important work. If she can find support she can run again.
+Robin: Looking for the issue. Ask Brian C.
+https://github.com/openjs-foundation/standards/issues/117
+Put the agenda tag on it.  Deadline is Nov 8th, 2022. 
+Flag it in slack too in case people don’t see it.
+Process
+Link to previous issue. Create issue
+Community Member posts in slack. Jordan will post it.
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.11.15_meeting_notes.md
+++ b/meeting-notes/2022.11.15_meeting_notes.md
@@ -1,0 +1,67 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-11-15
+
+## Links
+
+* **Recording**: https://www.youtube.com/watch?v=PP5navr6FB4
+* **GitHub Issue**: https://github.com/openjs-foundation/standards/issues/200
+
+## Present
+
+* Luke Schantz
+* Richard Gibson
+* Joe Sepi
+* Emeli Aro
+* Robin Ginn
+* Jory Burson
+* Lea Verou
+* Mike Champion
+
+## Agenda
+
+### Announcements
+
+CSL Webinar Announcement
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* 2022-2023 Public Calendar for web standards group meetings [#191](https://github.com/openjs-foundation/standards/issues/191)
+
+CSS WG Meetings - Wednesdays at Noon EST
+No dates yet for TC39
+OpenJS World co-locating May 8 OSSNA Vancouver
+Add link to the Readme on standards repo
+Add to website & collaboration page
+
+* Concise Guide to Participating in Web Standards Document WIP [#190](https://github.com/openjs-foundation/standards/issues/190)
+
+Need some contributions - real world examples. Talk to Dom / Dan / Mike T / Marcos?. Group to continue brainstorming - e.g. bugs from CSS WG. Lea to consider recent examples. Example from JSON Schema? Multiple kinds of examples could be helpful.
+Action: Lea to brainstorm CSS example
+Action: Jory / Robin &/or Luke Interview Ben Hutton
+
+
+
+
+* Define terms for SME Participation [#173](https://github.com/openjs-foundation/standards/issues/173)
+
+Use of community fund for SMEs - approval is for a year of travel. SME to provide an estimate for travel expenses for the year.
+Review reps in December for the upcoming year?
+Document this on GitHub
+
+* https://github.com/openjs-foundation/standards/issues/197
+	* is there anyone we would like to run from the OpenJS community?
+* What will the AB focus on now that the management duties have been upleveled to the Board?
+* Mike would be interested in the interim, but concerned about time commitments
+
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2022.11.29_meeting_notes.md
+++ b/meeting-notes/2022.11.29_meeting_notes.md
@@ -1,0 +1,58 @@
+# OpenJS Foundation Standards Working Group Meeting 2022-11-29
+
+## Links
+
+* **Recording**: https://youtube.com/live/JBNPYMradaY?feature=share
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+Jory Burson
+Robin Ginn
+Joe Sepi
+Jordan Harband
+Michael Champion
+Luke Schantz
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+
+
+## Agenda
+
+### Announcements
+
+TC39 in Spain
+
+FINOS in NYC Dec 8th
+
+Antitrust training on Dec. 13
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* 2022-2023 Public Calendar for web standards group meetings [#191](https://github.com/openjs-foundation/standards/issues/191)
+* Concise Guide to Participating in Web Standards Document WIP [#190](https://github.com/openjs-foundation/standards/issues/190)
+* Define terms for SME Participation [#173](https://github.com/openjs-foundation/standards/issues/173)
+
+* PRs
+* Calendar
+2023 events
+Should the WG meet in person in 2023
+Web App Sec Workship W3C
+Antitrust training
+Document!
+Dec 27 meeting canceled
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2023.02.07_meeting_notes.md
+++ b/meeting-notes/2023.02.07_meeting_notes.md
@@ -1,0 +1,86 @@
+TC39 was a couple of weeks ago
+Import assertions went down to stage 2
+Next Plenary 
+
+W3C
+	Tag F2F in Japan in April 
+
+AC Meeting in France at the same time as OpenJS World
+
+
+Participation in TC shouldn’t change?
+Reporting
+Participation is fluid
+
+
+# OpenJS Foundation Standards Working Group Meeting 2023-02-07
+
+## Links
+
+* **Recording**: https://youtube.com/live/vHM65WQQQ4I?feature=share
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+Luke Schantz
+Robin Ginn
+Joe Sepi
+Jory Burson
+Mike Champion
+Richard Gibson
+
+## Agenda
+
+### Announcements
+
+Google Season of Docs / Season of Code 
+W3C AB requesting input on sessions to cover at AC meeting
+Web Fonts WG - charter update for W3C
+W3C AB Election results:  
+Qing An (Alibaba Group)
+Tantek Çelik (Mozilla Foundation)
+Elika J Etemad (W3C Invited Expert)
+Charles Nevile (ConsenSys)
+OpenJS World Ticket Sales - May 9 is collab summit. 10-12 is the conference. This is in May! Vancouver.
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+Report or update from January/Feb TC39?
+Richard gave a brief report. One proposal went back - import assertions. 
+Process changes - active consensus - explicit report is now required. Better documentation on when things are ready for advancement https://github.com/tc39/how-we-work/pull/130 . Active consensus https://github.com/tc39/how-we-work/pull/122 .
+
+* 2022-2023 Public Calendar for web standards group meetings [#191](https://github.com/openjs-foundation/standards/issues/191)
+*Jory added meetings to TC39, TC53 & W3C meetings.
+*Checking on Unicode meetings and see what we should include on the public calendar.
+*Other groups who would be interested in being tracked on the public calendar. Avoid collisions. And find opportunities to coexist in the same space.
+*Winter CG has a public calendar
+
+* Concise Guide to Participating in Web Standards Document WIP [#190](https://github.com/openjs-foundation/standards/issues/190)
+*Jory to edit document this week and review it in next weeks meeting.
+
+* Define terms for SME Participation [#173](https://github.com/openjs-foundation/standards/issues/173)
+*Need to define how we are going to represent the details of a person, their expertise and how they are providing SME value in the documentation for an application for travel funds.
+*Action Item to write the policy in March.
+
+*OpenJS World and Summit & Standards Working Group
+*Content - program committee has been working.  We have 15 onsight sessions.  10 -15 virtual sessions. Portions of those sessions will be curated. 
+*The Standard track was well received in the past. 
+*Awards: Unsung hero, Leading by example, Outstanding contribution by a new arrival, Education
+*Event is the 9th. 3 or 4 weeks to have the award made and shipped. Need to have an award recommendation by April 4th.  Put a call out for nominations soon.
+* Security working group has planned a working session or public session at the Summit in the past.
+*Luke will let Claudio know about needing 1 hour for the Standards Working Group and coordinate follow up. 
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meeting-notes/2023.02.20_meeting_notes.md
+++ b/meeting-notes/2023.02.20_meeting_notes.md
@@ -1,0 +1,37 @@
+# OpenJS Foundation Standards Working Group Meeting 2023-02-20
+
+## Links
+
+* **Recording**: https://youtu.be/U4AWd4jAHHs
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+* OpenJS Foundation Cross Project Council
+* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors
+
+
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Standards Group Participation at OpenJS World  [#205](https://github.com/openjs-foundation/standards/issues/205)
+* Concise Guide to Participating in Web Standards Document WIP [#190](https://github.com/openjs-foundation/standards/issues/190)
+* Define terms for SME Participation [#173](https://github.com/openjs-foundation/standards/issues/173)
+
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+

--- a/meeting-notes/2023.03.07_meeting_notes.md
+++ b/meeting-notes/2023.03.07_meeting_notes.md
@@ -1,0 +1,46 @@
+# OpenJS Foundation Standards Working Group Meeting 2023-03-07
+
+## Links
+
+* **Recording**: https://youtu.be/89Opm3Q9z9A
+* **GitHub Issue**: https://github.com/openjs-foundation/standards/issues/208
+
+## Present
+
+* Jory Burson
+* Richard Gibson
+* Lea Verou
+* Guy Bedford
+* Joe Sepi (@joesepi)
+* Jordan Harband (@ljharb)
+* Darcy Clarke (@darcyclarke)
+* 
+
+## Agenda
+
+### Announcements
+
+*Extracted from **cross-project-council-agenda** labeled issues and pull requests from the **openjs-foundation org** prior to the meeting.
+
+### openjs-foundation/standards
+
+* Standards Group Participation at OpenJS World  [#205](https://github.com/openjs-foundation/standards/issues/205)
+
+* Concise Guide to Participating in Web Standards Document WIP [#190](https://github.com/openjs-foundation/standards/issues/190)
+
+* Define terms for SME Participation [#173](https://github.com/openjs-foundation/standards/issues/173)
+
+## Q&A, Other
+
+* Is there interest &/or potential resourcing available to help standardize [SemVer](https://semver.org/) as a Web API? (ref. https://github.com/nodejs/tooling/issues/146) ~ @darcyclarke
+  * Is this the right venue? If not, where should this be brought?
+  * This proposal was originally brought to the Node.js Tooling WG but there’s limited availability & OpenJSF has access to/connections with ECMA, W3C, OSI etc.
+  * Various pieces of feedback have been given about where the implementation could/should live (runtime/web api etc.)
+  * Scope of this functionality may be limited to the 2.0.0 schema & corresponding comparators (may not be 1:1 with “node-semver” - as that expands on range comparators)
+
+
+## Upcoming Meetings
+
+* **Calendar**: <https://calendar.openjsf.org>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.


### PR DESCRIPTION
I didn't have time to do clean up on these, just look for meeting recordings (I know we had several instances wherein the zoom to youtube feature wasn't working).