### PR TITLE
Add Tobie Langel to W3C representatives

### DIFF
--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -17,6 +17,7 @@ The following document lists OpenJS Foundation members and their representation 
   * Brian Kardell
   * Jory Burson (AC)
   * Michael Champion
+  * Tobie Langel
 
 [TC39]: https://github.com/tc39
 [TC53]: https://www.ecma-international.org/technical-committees/tc53/


### PR DESCRIPTION
I'd like to continue being involved with W3C as I have been in the past and promote collaboration between open source and standards; JavaScript and web developers, standards editors, browser vendors, and the broader Web community.