### PR TITLE
Make Michael Champion W3C AC Rep

### DIFF
--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -49,8 +49,8 @@ The following document lists OpenJS Foundation's memberships and liaison relatio
   * All Affiliated Accounts
     * Richard Gibson
     * Brian Kardell
-    * Jory Burson (AC Rep.)
-    * Michael Champion
+    * Jory Burson
+    * Michael Champion (AC Rep.)
     * Tobie Langel (Alt AC Rep.)
     * Anne-Gaelle Colom
     * David Methvin


### PR DESCRIPTION
Following decision from @jorydotcom to step down and discussion in todays's bi-weekly call.