### PR TITLE
🚚 WinterCG -> WinterTC

### DIFF
--- a/MEMBER_REPRESENTATION.md
+++ b/MEMBER_REPRESENTATION.md
@@ -18,6 +18,9 @@ The following document lists OpenJS Foundation's memberships and liaison relatio
   * [TC54]
     * Chris de Almeida (IBM)
     * Jordan Harband (HeroDevs)
+  * [TC55]
+    * Chris de Almeida *
+    * Jordan Harband (HeroDevs)
   * General Assembly Representative
     * Jory Burson *
 * [Open Source Initiative]
@@ -27,11 +30,6 @@ The following document lists OpenJS Foundation's memberships and liaison relatio
 * [Unicode MessageFormat Working Group]
   * Eemeli Aro*
 * [W3C]
-  * [Web-interoperable Runtimes Community Group]
-    * Jory Burson *
-    * Robin Ginn *
-    * Jordan Harband
-    * Ethan Arrowood (Vercel)
   * [Web History Community Group]
     * Brian Kardell * (Igalia)
   * [Web Platform Incubator Community Group]


### PR DESCRIPTION
as discussed in today's meeting, WinterCG is no more and has been superseded by WinterTC.  also nominated myself to represent OpenJS at TC55, as we are still working through internal processes at IBM. there were no objections at the meeting today